### PR TITLE
Fix script tag closing error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ hotkeys('ctrl+a,ctrl+b,r,f', function(event,handler) {
     case "f":alert('you pressed f!');break;
   }
 });
-<script>
+</script>
 ```
 
 ### Used in React


### PR DESCRIPTION
The last line of the usage example incorrectly closes the script tag.  This is a problem for new users of the code as the initial example code would not work. This fixes that error.